### PR TITLE
增加钉钉多部门支持

### DIFF
--- a/ali_dindin/data/system_conf.xml
+++ b/ali_dindin/data/system_conf.xml
@@ -118,8 +118,11 @@
 			<field name="key">user_delete</field>
 			<field name="value">https://oapi.dingtalk.com/user/delete?access_token=</field>
 		</record>
-
-
+    <record id="ali_dindin_system_conf_user_get" model="ali.dindin.system.conf">
+			<field name="name">获取用户详情</field>
+			<field name="key">user_get</field>
+			<field name="value">https://oapi.dingtalk.com/user/get?access_token=</field>
+		</record>
 
 
     </data>

--- a/ali_dindin/models/employee.py
+++ b/ali_dindin/models/employee.py
@@ -211,7 +211,7 @@ class HrEmployee(models.Model):
         :param time_num:
         :return:
         """
-        time_stamp = float(time_num / 1000)
+        time_stamp = float(time_num / 1000 + 28800) # 从钉钉时间戳转成odoo日期，差一天，暂时这样解决
         time_array = time.localtime(time_stamp)
         return time.strftime("%Y-%m-%d", time_array)
 

--- a/ali_dindin/models/employee.py
+++ b/ali_dindin/models/employee.py
@@ -97,7 +97,7 @@ class HrEmployee(models.Model):
                 'jobnumber': res.din_jobnumber if res.din_jobnumber else '',  # 工号
             }
             if res.din_hiredDate:
-                hiredDate = self.time_to_timestamp(res.din_hiredDate)
+                hiredDate = self.date_to_stamp(res.din_hiredDate)
                 data.update({'hiredDate': hiredDate})
 
             headers = {'Content-Type': 'application/json'}
@@ -150,9 +150,9 @@ class HrEmployee(models.Model):
                         'din_avatar': result.get('avatar') if result.get('avatar') else '',  # 钉钉头像url
                     }
                     if result.get('hiredDate'):
-                        time_stamp = self.get_time_stamp(result.get('hiredDate'))
+                        date_str = self.get_time_stamp(result.get('hiredDate'))
                         data.update({
-                            'din_hiredDate': time_stamp,
+                            'din_hiredDate': date_str,
                         })
                     if result.get('department'):
                         dep_din_ids = result.get('department')
@@ -213,19 +213,22 @@ class HrEmployee(models.Model):
         """
         time_stamp = float(time_num / 1000)
         time_array = time.localtime(time_stamp)
-        return time.strftime("%Y-%m-%d %H:%M:%S", time_array)
+        return time.strftime("%Y-%m-%d", time_array)
+
+
 
     # 把时间转成时间戳形式
     @api.model
-    def time_to_timestamp(self, time_str):
+    def date_to_stamp(self, date):
         """
         将时间转成13位时间戳
         :param time_num:
         :return:
         """
-        time_stamp = time.mktime(time_str.timetuple())
-        time_stamp = time_stamp * 1000
-        return time_stamp
+        date_str = fields.Date.to_string(date)
+        date_stamp = time.mktime(time.strptime(date_str, "%Y-%m-%d"))
+        date_stamp = date_stamp * 1000
+        return date_stamp
 
 
 # 未使用，但是不能删除，因为第一个版本创建的视图还存在

--- a/ali_dindin/models/employee.py
+++ b/ali_dindin/models/employee.py
@@ -96,6 +96,10 @@ class HrEmployee(models.Model):
                 'email': res.work_email if res.work_email else '',  # 邮箱
                 'jobnumber': res.din_jobnumber if res.din_jobnumber else '',  # 工号
             }
+            if res.din_hiredDate:
+                hiredDate = self.time_to_timestamp(res.din_hiredDate)
+                data.update({'hiredDate': hiredDate})
+
             headers = {'Content-Type': 'application/json'}
             try:
                 result = requests.post(url="{}{}".format(url, token), headers=headers, data=json.dumps(data),
@@ -210,6 +214,19 @@ class HrEmployee(models.Model):
         time_stamp = float(time_num / 1000)
         time_array = time.localtime(time_stamp)
         return time.strftime("%Y-%m-%d %H:%M:%S", time_array)
+
+    # 把时间转成时间戳形式
+    @api.model
+    def time_to_timestamp(self, time_str):
+        """
+        将时间转成13位时间戳
+        :param time_num:
+        :return:
+        """
+        time_stamp = time.mktime(time_str.timetuple())
+        time_stamp = time_stamp * 1000
+        return time_stamp
+
 
 # 未使用，但是不能删除，因为第一个版本创建的视图还存在
 class DinDinSynchronousEmployee(models.TransientModel):

--- a/ali_dindin/models/synchronous.py
+++ b/ali_dindin/models/synchronous.py
@@ -4,6 +4,7 @@ import json
 import logging
 import time
 import requests
+from requests import ReadTimeout
 from odoo import api, fields, models, tools
 from odoo.exceptions import UserError
 
@@ -128,6 +129,10 @@ class DingDingSynchronous(models.TransientModel):
                         logging.info(">>>--------------------------------")
                         logging.info(">>>SSL异常:{}".format(e))
                         logging.info(">>>--------------------------------")
+                if user.get('department'):
+                        dep_din_ids = user.get('department')
+                        dep_list = self.env['hr.department'].sudo().search([('din_id', 'in', dep_din_ids)])
+                        data.update({'department_ids': [(6, 0, dep_list.ids)]})
                 employee = self.env['hr.employee'].search(['|', ('din_id', '=', user.get('userid')), ('name', '=', user.get('name'))])
                 if employee:
                     employee.sudo().write(data)

--- a/ali_dindin/views/employee.xml
+++ b/ali_dindin/views/employee.xml
@@ -25,6 +25,9 @@
                         />
                     </div>
             </xpath>
+            <xpath expr="//field[@name='department_id']" position="after">
+                <field name="department_ids" widget="many2many_tags"/>
+            </xpath>
             <button name="toggle_active" position="before">
                 <button name="create_ding_employee" string="上传至钉钉" type="object" class="oe_stat_button"
                         icon="fa-hand-scissors-o" attrs="{'invisible':[('dingding_type','=', 'yes')]}"
@@ -50,7 +53,7 @@
     </record>
 
     <record id='using_dingding_avatar_action' model='ir.actions.server'>
-        <field name='name'>Using avatar</field>
+        <field name='name'>使用钉钉头像</field>
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="binding_model_id" ref="model_hr_employee"/>
         <field name="state">code</field>
@@ -59,4 +62,16 @@ if records:
     action = records.using_dingding_avatar()
         </field>     
     </record>
+
+    <record id='update_employee_from_dingding_action' model='ir.actions.server'>
+        <field name='name'>从钉钉更新</field>
+        <field name="model_id" ref="hr.model_hr_employee"/>
+        <field name="binding_model_id" ref="model_hr_employee"/>
+        <field name="state">code</field>
+        <field name="code">
+if records:
+    action = records.update_employee_from_dingding()
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
1.修复从odoo同步到钉钉，部门无法同步问题。
2.增加department_ids字段，用于匹配钉钉的多部门列表。
3.增加获取用户详情api，实现从钉钉更新当前员工详情